### PR TITLE
BUGFIX-RELEASE: don't persist credentials in github actions release

### DIFF
--- a/.github/workflows/node.js-test.yml
+++ b/.github/workflows/node.js-test.yml
@@ -41,6 +41,8 @@ jobs:
     if: ${{  !contains(github.event.head_commit.message, '[ci skip]') && github.ref == 'refs/heads/master' }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Use Node.js 12.19
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
## Description

https://github.com/marketplace/actions/action-for-semantic-release

> IMPORTANT: GITHUB_TOKEN does not have the required permissions to operate on protected branches. If you are using this action for protected branches, replace GITHUB_TOKEN with Personal Access Token. If using the @semantic-release/git plugin for protected branches, avoid persisting credentials as part of actions/checkout@v2 by setting the parameter persist-credentials: false. This credential does not have the required permission to operate on protected branches.

release failed due to persisting the old github token env variable. setting the persist credentials to false should make sure it chooses the Adobe Bot PAT instead of the global org secret.

I set up my own repo, PAT, and NPM bot token to test this & it worked: https://github.com/jdelbick/ci-release-dummy-repo/runs/1489321606
[v1.0.0](https://www.npmjs.com/package/ci-release-dummy-test)
It uses the same workflow config with my own tokens & based off of branch `main`: https://github.com/jdelbick/ci-release-dummy-repo/blob/main/.github/workflows/node.js-test.yml#L53-L54 
So if this change does not work, we know it is some wrong with the Adobe Bot token or some repo setting

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
